### PR TITLE
1223 add character limit

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kjetil-hoel/design-system-svelte",
   "license": "MIT",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",

--- a/packages/svelte/src/lib/components/Form/CharacterCounter.svelte
+++ b/packages/svelte/src/lib/components/Form/CharacterCounter.svelte
@@ -1,0 +1,83 @@
+<script>
+  export let label = defaultLabel;
+  export let srLabel = '';
+  export let maxCount;
+  export let value;
+  export let id;
+  export let size = 'medium';
+
+  let fontSizeClass;
+  switch (size) {
+    case 'xsmall':
+      fontSizeClass = 'font-xsmall';
+      break;
+    case 'small':
+      fontSizeClass = 'font-small';
+      break;
+    case 'medium':
+      fontSizeClass = 'font-medium';
+      break;
+    case 'large':
+      fontSizeClass = 'font-large';
+      break;
+    default:
+      fontSizeClass = 'font-medium';
+      break;
+  }
+
+  function defaultLabel(count) {
+    return count > -1
+      ? `${count} tegn igjen`
+      : `${Math.abs(count)} tegn for mye`;
+  }
+
+  function defaultSrLabel(maxCount) {
+    return `Tekstfelt med plass til ${maxCount} tegn`;
+  }
+
+  $: currentCount = maxCount - value.length;
+  $: hasExceededLimit = value.length > maxCount;
+  $: finalSrLabel = srLabel || defaultSrLabel(maxCount);
+</script>
+
+<span
+  class={`visuallyHidden ${fontSizeClass}`}
+  {id}
+>
+  {finalSrLabel}
+</span>
+
+<span
+  class={`${hasExceededLimit ? 'error' : ''} ${fontSizeClass}`}
+  aria-live={hasExceededLimit ? 'polite' : 'off'}
+>
+  {label ? label(currentCount) : defaultLabel(currentCount)}
+</span>
+
+<style>
+  .error {
+    color: red;
+  }
+
+  .visuallyHidden {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+  }
+
+  .font-xsmall {
+    font-size: 0.8125rem;
+  }
+  .font-small {
+    font-size: 0.9375rem;
+  }
+  .font-medium {
+    font-size: 1.125rem;
+  }
+  .font-large {
+    font-size: 1.25rem;
+  }
+</style>

--- a/packages/svelte/src/lib/components/Form/Radio/Radio.svelte
+++ b/packages/svelte/src/lib/components/Form/Radio/Radio.svelte
@@ -63,6 +63,11 @@
       fontSizeClass = 'font-medium';
       spacingClass = 'spacing-medium';
       break;
+    case 'large':
+      iconSizeClass = 'icon-large';
+      fontSizeClass = 'font-large';
+      spacingClass = 'spacing-large';
+      break;
     default:
       iconSizeClass = 'icon-medium';
       fontSizeClass = 'font-medium';
@@ -328,6 +333,10 @@
       height: 2rem;
       width: 2rem;
     }
+    .icon-large {
+      height: 2.25rem;
+      width: 2.25rem;
+    }
 
     .font-xsmall {
       font-size: 0.8125rem;
@@ -337,6 +346,9 @@
     }
     .font-medium {
       font-size: 1.125rem;
+    }
+    .font-large {
+      font-size: 1.25rem;
     }
   }
 </style>

--- a/packages/svelte/src/lib/components/Form/Textfield/Textfield.svelte
+++ b/packages/svelte/src/lib/components/Form/Textfield/Textfield.svelte
@@ -1,4 +1,7 @@
 <script>
+  import CharacterCounter from '../CharacterCounter.svelte';
+  import { v4 as uuidv4 } from 'uuid';
+
   /**
    * Text input field
    *
@@ -17,8 +20,6 @@
    * @prop {any} [characterLimitLabel=null] - Sets custom label for shown character limit (function is possible to pass in, see example).
    */
 
-  import CharacterCounter from '../CharacterCounter.svelte';
-
   export let label = '';
   export let description = '';
   export let size = 'medium';
@@ -32,6 +33,8 @@
   export let suffix = '';
   export let characterLimit = null;
   export let characterLimitLabel = null;
+
+  let componentId = uuidv4();
 
   // Computed class names for the component elements
   let formFieldClasses = `form-field ${size} ${disabled ? 'disabled' : ''} ${
@@ -101,7 +104,7 @@
     <CharacterCounter
       maxCount={characterLimit}
       {value}
-      id="characterCountLabel"
+      id={`character-counter-${componentId}`}
       {size}
       label={characterLimitLabel}
     />

--- a/packages/svelte/src/lib/components/Form/Textfield/Textfield.svelte
+++ b/packages/svelte/src/lib/components/Form/Textfield/Textfield.svelte
@@ -13,7 +13,12 @@
    * @prop {string} [error] - Error message to display.
    * @prop {string} [prefix] - Prefix for field.
    * @prop {string} [suffix] - Suffix for field.
+   * @prop {number} [characterLimit=null] - Sets limit for number of characters.
+   * @prop {any} [characterLimitLabel=null] - Sets custom label for shown character limit (function is possible to pass in, see example).
    */
+
+  import CharacterCounter from '../CharacterCounter.svelte';
+
   export let label = '';
   export let description = '';
   export let size = 'medium';
@@ -25,6 +30,8 @@
   export let error = false;
   export let prefix = '';
   export let suffix = '';
+  export let characterLimit = null;
+  export let characterLimitLabel = null;
 
   // Computed class names for the component elements
   let formFieldClasses = `form-field ${size} ${disabled ? 'disabled' : ''} ${
@@ -90,6 +97,15 @@
       </div>
     {/if}
   </div>
+  {#if characterLimit}
+    <CharacterCounter
+      maxCount={characterLimit}
+      {value}
+      id="characterCountLabel"
+      {size}
+      label={characterLimitLabel}
+    />
+  {/if}
   {#if error}
     <div
       class={errorMessageClasses}

--- a/packages/svelte/src/routes/+page.svelte
+++ b/packages/svelte/src/routes/+page.svelte
@@ -76,7 +76,15 @@
   >First Icon</Button
 >
 
-<Textfield bind:value={textfieldValue} />
+<Textfield
+  bind:value={textfieldValue}
+  size="small"
+  characterLimit={10}
+  characterLimitLabel={(count) =>
+    count > -1
+      ? `Du har ${count} tegn igjen.`
+      : `Du har ${Math.abs(count)} tegn for mye.`}
+/>
 
 <Link href="/route">Link</Link>
 <Paragraph


### PR DESCRIPTION
Jeg fikk plutselig ikke sove etter en lang dag, så da ble det litt react til svelte-konvertering nå i kveldinga. 

Her har jeg forsøkt meg på å konvertere samme funksjonalitet for characterLimit i Textfield som allerede finnes i React-koden i dag. Jeg har også lagt til "large"-size for Radio. 

Tekststørrelser og font-typer tenker jeg vi kan endre på når vi tar i bruk design tokenet til Liv Elin. Enn så lenge har jeg bare hardkodet noen verdier for xsmall, small, medium og large.